### PR TITLE
Fix path service test coverage

### DIFF
--- a/__tests__/path.service.test.js
+++ b/__tests__/path.service.test.js
@@ -109,9 +109,9 @@ describe("path.service editPath()", () => {
     });
 
     it("throws an error if a sent answer ID does not exist within that page in the JSON", () => {
-      expect(() => editPath(pathJSON, ["example-Invalid-Answer"])).toThrow(
-        Error
-      );
+      expect(() =>
+        editPath(pathJSON, ["example-Invalid-Answer"], "/index")
+      ).toThrow(Error);
     });
 
     it("does not deactivate or reactivate the current page", () => {

--- a/services/path.service.js
+++ b/services/path.service.js
@@ -35,34 +35,31 @@ module.exports.editPath = (originalPath, answerArray, currentPage) => {
   const newPath = JSON.parse(JSON.stringify(originalPath));
   let pagesToSwitch = {};
 
-  if (answerArray) {
-    const allSwitches = {};
-    for (let page in originalPath) {
-      Object.assign(allSwitches, originalPath[page].switches);
-    }
-    // const referenceOrder = Object.keys(originalPath[currentPage].switches);
-    answerArray.sort((a, b) => {
-      return (
-        Object.keys(allSwitches).indexOf(a) -
-        Object.keys(allSwitches).indexOf(b)
-      );
-    });
-    answerArray.forEach(answerID => {
-      if (allSwitches[answerID]) {
-        pagesToSwitch = Object.assign(pagesToSwitch, allSwitches[answerID]);
-      } else {
-        throw new Error(`
+  const allSwitches = {};
+  for (let page in originalPath) {
+    Object.assign(allSwitches, originalPath[page].switches);
+  }
+  // const referenceOrder = Object.keys(originalPath[currentPage].switches);
+  answerArray.sort((a, b) => {
+    return (
+      Object.keys(allSwitches).indexOf(a) - Object.keys(allSwitches).indexOf(b)
+    );
+  });
+  answerArray.forEach(answerID => {
+    if (allSwitches[answerID]) {
+      pagesToSwitch = Object.assign(pagesToSwitch, allSwitches[answerID]);
+    } else {
+      throw new Error(`
           path.service.js editPath(): The answer "${answerID}" does not exist in the path JSON.
           If "${answerID}" is intended to change the path of the registration form, update the path JSON.
           Else, remove the prefix from the name to make it a non-path answer ID.
         `);
-      }
-    });
+    }
+  });
 
-    for (let eachPage in pagesToSwitch) {
-      if (eachPage !== currentPage) {
-        newPath[eachPage].on = pagesToSwitch[eachPage];
-      }
+  for (let eachPage in pagesToSwitch) {
+    if (eachPage !== currentPage) {
+      newPath[eachPage].on = pagesToSwitch[eachPage];
     }
   }
 


### PR DESCRIPTION
Added one argument to a test that was missing, and removed an if() statement that was unnecessary (it always went for the 'truthy' path because the check had already been made prior to it reaching that if statement)